### PR TITLE
timeBeforeLastUpdated

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2379,3 +2379,10 @@ acronym, abbr, fieldset, img {
      height:10px;
      margin:5px 2% 0px 2%;
 }
+
+#last-updated {
+    z-index: 0;
+}
+#hacker-clock {
+    z-index: 1;
+}


### PR DESCRIPTION
Sometimes the last digit of the time (<p id="hacker-clock">) is behind the last updated field
(<p id="last-updated"), sometimes not. This is because the z-index css was not set for neither
of the two p-Elements. Thus the browser could either show hacker-clock before last-updated or
versus visa. (So sometimes, but not always, the browser showed a part of the last digit in the
hacker-clock behind the last-updated <p>.)

In order to get a uniform, good looking behaviour show the hacker-clock before last-updated.
Thus it is guaranteed that the last digit of the hacker-clock p-Element is always completely
visible.